### PR TITLE
Use levelup 0.10.x and leveldown 0.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
       , "xtend"           : "~2.0.3"
     }
   , "peerDependencies": {
-        "levelup"         : "~0.8.0"
+        "levelup"         : "~0.10.0"
     }
   , "devDependencies" : {
         "tap"             : "*"
-      , "levelup"         : "~0.8.0"
+      , "levelup"         : "~0.10.0"
+      , "leveldown"       : "~0.6.0"
       , "request"         : "~2.12.0"
       , "cookies"         : "~0.3.6"
       , "rimraf"          : "~2.1.1"


### PR DESCRIPTION
Hey!

I'm trying to get level-session to work with the latest version of levelup & leveldown.
There are, however, a few tests that fails..

I'll take a look at why later, just wanted to give you a heads up now in case you know what the problem is about.
