### PR TITLE
After destroying a db read stream, fire the callback by hand.

### DIFF
--- a/level-store.js
+++ b/level-store.js
@@ -129,8 +129,10 @@ LevelStore.prototype._forEach = function (id, fn, callback) {
       var lkey = data.key.split(SEP_CHAR)
       if (lkey[0] == id)
         fn(lkey[1], data.value)
-      else if (lkey.length != 2 || lkey[0] > id)
+      else if (lkey.length != 2 || lkey[0] > id) {
         rs.destroy()
+        callback()
+      }
     })
     .on('end', callback)
 }


### PR DESCRIPTION
The 'end' event appears not to be firing, so the callback has to be invoked here. The symptom I observed was a hang when attempting to look up a session for a user without one, in a non-empty session database. To repro, create a session in the db then try to look one up.
