### PR TITLE
remove level-sublevel. not used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "generic-session": "~0.0.2",
-    "level-sublevel": "~5.1.1",
     "level-ttl": "^2.1.1",
     "xtend": "~2.1.1"
   },


### PR DESCRIPTION
This dependency was not used.

There was a breaking change between v6 & v5. I'm auditing all
    level-sublevel dependencies in my application using
    `npm ls level-sublevel`.

I saw level-session was using the old level-sublevel but it
    was a false alarm.

We should remove unused dependencies.

cc @rvagg
