### PR TITLE
add options.ttl to pass options into level-ttl

### DIFF
--- a/level-store.js
+++ b/level-store.js
@@ -39,7 +39,7 @@ function LevelStore (options) {
     , valueEncoding   : 'utf8'
   })
 
-  this._db = ttl(this._db)
+  this._db = ttl(this._db, options.ttl)
 }
 
 LevelStore.prototype.get = function (id, key, expire, callback) {


### PR DESCRIPTION
this is so level-session users can pass in options for this https://github.com/rvagg/node-level-ttl/pull/18

maybe a better approach would be the ability to pass in a custom level-ttl instance instead that is already configured, but meh, i dunno the best thing to do here
